### PR TITLE
Added option to specify virtual root

### DIFF
--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -105,6 +105,13 @@ function handleRequest(request, response, grunt, options) {
 		}
 	}
 	
+	// is this url contains virtual root? If so, remove it
+	if (options.virtualRoot) {
+		if (path.indexOf(options.virtualRoot) === 0) {
+			path = path.substr(options.virtualRoot.length);
+		}
+	}
+
 	// does this path match an alias?
 	var aliasName = path.substr(1);
 	var aliases = options.aliases;


### PR DESCRIPTION
To help work better with code in webstorm, i need to be able to specify virtual root, as by default all the code served by webstorm goes to: localhost:port/src/
And all the other dev web servers, like grunt serve, do not have this prefix, 
This adds an optional config parameter for grunt serve, to specify virtual root.